### PR TITLE
refactor: Check if face attribute is string before applying inversion

### DIFF
--- a/automagic-dark-mode.el
+++ b/automagic-dark-mode.el
@@ -36,11 +36,13 @@ the previously existing attribute."
 	(let* ((customization-list (automagic-dark--initial-face-list f))
 	       (orig-fg (face-attribute f :foreground nil t))
 	       (orig-bg (face-attribute f :background nil t)))
-	  (when (and orig-fg (not (eq orig-fg 'unspecified)))
+	  (when (and orig-fg (not (or (eq orig-fg 'unspecified)
+                                      (eq orig-fg 'reset))))
 	    (setq customization-list
 		  (append (automagic-dark--color-customization f inversion-function)
 			  customization-list)))
-	  (when (and orig-bg (not (eq orig-bg 'unspecified)))
+	  (when (and orig-bg (not (or (eq orig-bg 'unspecified)
+                                      (eq orig-bg 'reset))))
 	    (setq customization-list
 		  (append (automagic-dark--color-customization f #'automagic-dark-scaled-luminance-invert :background)
 			  customization-list)))

--- a/automagic-dark-mode.el
+++ b/automagic-dark-mode.el
@@ -5,7 +5,9 @@
   "Apply inversion function to an attribute and return the customization list"
   (let* ((attr     (if background-p :background :foreground))
          (orig-col (face-attribute face attr nil t))
-	 (new-col (apply inversion-function (list orig-col))))
+	 (new-col (if (stringp orig-col)
+                      (funcall inversion-function orig-col)
+                    orig-col)))
     (list attr new-col)))
 
 

--- a/automagic-dark-mode.el
+++ b/automagic-dark-mode.el
@@ -5,9 +5,7 @@
   "Apply inversion function to an attribute and return the customization list"
   (let* ((attr     (if background-p :background :foreground))
          (orig-col (face-attribute face attr nil t))
-	 (new-col (if (stringp orig-col)
-                      (funcall inversion-function orig-col)
-                    orig-col)))
+	 (new-col (apply inversion-function (list orig-col))))
     (list attr new-col)))
 
 


### PR DESCRIPTION
Avoid this error when toggling:

Debugger entered--Lisp error: (wrong-type-argument stringp reset)
xw-color-values(reset nil)
color-values(reset nil)
color-name-to-rgb(reset)
automagic-dark-luminance-invert(reset)
automagic-dark-invert-luminance-with-wcag-contrast(reset)
automagic-dark--color-customization(forge-topic-header-line automagic-dark-invert-luminance-with-wcag-contrast)
automagic-dark--invert-all-faces(automagic-dark-invert-luminance-with-wcag-contrast)
automagic-dark-mode(toggle)
funcall-interactively(automagic-dark-mode toggle)
call-interactively(automagic-dark-mode nil nil)
command-execute(automagic-dark-mode)